### PR TITLE
Remove `...` from the body

### DIFF
--- a/src/views/layouts/main.html
+++ b/src/views/layouts/main.html
@@ -95,7 +95,6 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
     {{ super()}}
   {%block scripts %}
     <body>
-      ...
       <script type="module" src="/assets/all.js"></script>
       <script type="module">
         window.GOVUKPrototypeComponents.initAll()


### PR DESCRIPTION
## What

Remove `...` from the body

## Why

This was added in unintentionally.

## Before

<img width="1669" alt="Screenshot 2024-08-28 at 4 43 13 PM" src="https://github.com/user-attachments/assets/7349a114-7b24-4564-8ee3-34bf02555415">

## After

<img width="1666" alt="Screenshot 2024-08-28 at 4 43 29 PM" src="https://github.com/user-attachments/assets/baefc267-0755-4ee3-b4cf-e6130b6ec24a">
